### PR TITLE
added MQTT connection and disconnection error handling

### DIFF
--- a/python/mqtt/mqtt_exceptions.py
+++ b/python/mqtt/mqtt_exceptions.py
@@ -1,0 +1,7 @@
+class MQTTConnectionError(Exception):
+    """Custom exception for MQTT connection failures."""
+    pass
+
+class MQTTDisconnectError(Exception):
+    """Custom exception for MQTT disconnect failures."""
+    pass

--- a/python/mqtt/mqtt_sink.py
+++ b/python/mqtt/mqtt_sink.py
@@ -37,7 +37,6 @@ class mqtt_sink(gr.sync_block):
         self.client.tls_insecure_set(True)
         self.client.on_connect_fail = self.mqtt_connect_fail
         self.client.on_disconnect = self.mqtt_disconnect
-
         self.client.connect(host, port, 30)
         self.client.loop_start()            
 

--- a/python/mqtt/mqtt_source.py
+++ b/python/mqtt/mqtt_source.py
@@ -13,6 +13,8 @@ import paho.mqtt.client as paho_mqtt
 import pmt
 from gnuradio import gr
 import ssl
+from .mqtt_exceptions import MQTTConnectionError, MQTTDisconnectError
+
 
 
 class mqtt_source(gr.sync_block):
@@ -35,10 +37,11 @@ class mqtt_source(gr.sync_block):
         #NOTE(bcwaldon): temporary until we have real TLS config
         self.client.tls_set(cert_reqs=ssl.CERT_NONE)
         self.client.tls_insecure_set(True)
+        self.client.on_connect_fail = self.mqtt_connect_fail
+        self.client.on_disconnect = self.mqtt_disconnect
 
         self.client.connect(host, port, 30)
         self.client.loop_start()
-
         self.client.on_message = self.handle
         self.client.subscribe(topic)
 
@@ -51,3 +54,17 @@ class mqtt_source(gr.sync_block):
             pmt.intern("message"),
             pmt.init_u8vector(len(raw_msg), raw_msg)
         )
+
+    def mqtt_connect_fail(self, client, userdata, rc):
+        try:
+            reason_text = paho_mqtt.error_string(rc) 
+        except ValueError:
+            reason_text = f"Unknown reason code: {rc}"
+        raise MQTTConnectionError(f"Disconnected from MQTT broker: {reason_text}")
+    
+    def mqtt_disconnect(self, client, userdata, rc):
+        try:
+            reason_text = paho_mqtt.error_string(rc) 
+        except ValueError:
+            reason_text = f"Unknown reason code: {rc}"
+        raise MQTTDisconnectError(f"Disconnected from MQTT broker: {reason_text}")

--- a/python/mqtt/mqtt_source.py
+++ b/python/mqtt/mqtt_source.py
@@ -39,7 +39,6 @@ class mqtt_source(gr.sync_block):
         self.client.tls_insecure_set(True)
         self.client.on_connect_fail = self.mqtt_connect_fail
         self.client.on_disconnect = self.mqtt_disconnect
-
         self.client.connect(host, port, 30)
         self.client.loop_start()
         self.client.on_message = self.handle


### PR DESCRIPTION
Add error handling to MQTT blocks to prevent silent failures. Intention is to stop the flowgraph if a connection is not established or is dropped after being established.